### PR TITLE
chore: fix check-kubebuilder-release.yml

### DIFF
--- a/.github/workflows/check-kubebuilder-release.yml
+++ b/.github/workflows/check-kubebuilder-release.yml
@@ -12,7 +12,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          latest_version=$(curl --silent "https://api.github.com/repos/kubernetes-sigs/kubebuilder/releases" | jq -r '.[].tag_name' | head -10 | sort -r | head -1)
+          latest_version=$(curl --silent "https://api.github.com/repos/kubernetes-sigs/kubebuilder/releases" | jq -r '. | sort_by(.published_at) | reverse | .[] | select(.tag_name | test("^v[0-9]+.[0-9]+.0$") ) | .tag_name' | head -1)
           current_version=$(grep kubebuilder README.md | sed 's/.*\(v[0-9]\+.[0-9]\+.[0-9]\+\).*/\1/')
           current_minor_version=$(grep kubebuilder README.md | sed 's/.*\(v[0-9]\+.[0-9]\+\).*/\1/')
           latest_minor_version=$(echo ${latest_version} | sed 's/.*\(v[0-9]\+.[0-9]\+\).*/\1/')


### PR DESCRIPTION

```
curl --silent "https://api.github.com/repos/kubernetes-sigs/kubebuilder/releases" | jq -r '. | sort_by(.published_at) | reverse | .[] | select(.tag_name | test("^v[0-9]+.[0-9]+.0$") ) | .tag_name'
v3.10.0
v3.9.0
v3.8.0
v3.7.0
v3.6.0
v3.5.0
v3.4.0
v3.3.0
v3.2.0
v3.1.0
v3.0.0
v2.3.0
v2.2.0
v2.1.0
v2.0.0
```

